### PR TITLE
(fix) BitmapText font change

### DIFF
--- a/src/gameobjects/BitmapText.js
+++ b/src/gameobjects/BitmapText.js
@@ -528,6 +528,7 @@ Object.defineProperty(Phaser.BitmapText.prototype, 'font', {
         if (value !== this._font)
         {
             this._font = value.trim();
+            this._data = game.cache.getBitmapFont(this._font);
             this.updateText();
         }
 


### PR DESCRIPTION
Hi, 
2.4.2 Have an issue when changing the font, it doesn't refresh properly  (appears the old one) .
To fix it, is needed to load the new one. 

``` javascript
this._data = game.cache.getBitmapFont(this._font);
```

just before calling updateText
